### PR TITLE
[Feature/#31] 유저 로그인 시 fcm token을 저장하는 로직 구현

### DIFF
--- a/src/main/java/com/backend/auth/application/FcmTokenService.java
+++ b/src/main/java/com/backend/auth/application/FcmTokenService.java
@@ -1,0 +1,23 @@
+package com.backend.auth.application;
+
+import com.backend.auth.domain.FcmToken;
+import com.backend.auth.domain.FcmTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FcmTokenService {
+
+    private final FcmTokenRepository fcmTokenRepository;
+
+    private static final String FCM_TOKEN_PREFIX = "fcm";
+
+    public void saveFcmToken(String uid, String fcmToken){
+        fcmTokenRepository.save(new FcmToken(FCM_TOKEN_PREFIX + uid, fcmToken));
+    }
+
+    public String findFcmToken(String uid) {
+        return fcmTokenRepository.getById(FCM_TOKEN_PREFIX + uid).getFcmToken();
+    }
+}

--- a/src/main/java/com/backend/auth/application/OAuthService.java
+++ b/src/main/java/com/backend/auth/application/OAuthService.java
@@ -19,7 +19,7 @@ public class OAuthService {
 
     private final BlackListService blackListService;
 
-    public TokenResponse login(String provider, String uid) {
+    public TokenResponse login(String provider, String uid, String fcmToken) {
         memberService.findMemberOrRegister(Provider.from(provider), uid);
         String accessToken = tokenProvider.generateAccessToken(uid);
         String refreshToken = tokenProvider.generateRefreshToken(uid);

--- a/src/main/java/com/backend/auth/application/OAuthService.java
+++ b/src/main/java/com/backend/auth/application/OAuthService.java
@@ -19,11 +19,17 @@ public class OAuthService {
 
     private final BlackListService blackListService;
 
+    private final FcmTokenService fcmTokenService;
+
     public TokenResponse login(String provider, String uid, String fcmToken) {
         memberService.findMemberOrRegister(Provider.from(provider), uid);
+
         String accessToken = tokenProvider.generateAccessToken(uid);
         String refreshToken = tokenProvider.generateRefreshToken(uid);
+
         refreshTokenService.saveRefreshToken(uid, refreshToken);
+        fcmTokenService.saveFcmToken(uid, fcmToken);
+
         return new TokenResponse(accessToken, refreshToken);
     }
 
@@ -31,8 +37,10 @@ public class OAuthService {
         String refreshToken = tokenProvider.getToken(bearerRefreshToken);
 
         String uid = refreshTokenService.findUidByRefreshToken(refreshToken);
+
         String renewAccessToken = tokenProvider.generateAccessToken(uid);
         String renewRefreshToken = tokenProvider.generateRefreshToken(uid);
+
         return new TokenResponse(renewAccessToken, renewRefreshToken);
     }
 

--- a/src/main/java/com/backend/auth/domain/FcmToken.java
+++ b/src/main/java/com/backend/auth/domain/FcmToken.java
@@ -1,0 +1,16 @@
+package com.backend.auth.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@AllArgsConstructor
+@RedisHash(value="fcmToken")
+public class FcmToken {
+    @Id
+    private String uid;
+
+    private String fcmToken;
+}

--- a/src/main/java/com/backend/auth/domain/FcmTokenRepository.java
+++ b/src/main/java/com/backend/auth/domain/FcmTokenRepository.java
@@ -1,0 +1,11 @@
+package com.backend.auth.domain;
+
+import com.backend.global.common.code.ErrorCode;
+import com.backend.global.exception.BusinessException;
+import org.springframework.data.repository.CrudRepository;
+
+public interface FcmTokenRepository extends CrudRepository<FcmToken, String> {
+    default FcmToken getById(String uid){
+        return findById(uid).orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/backend/auth/presentation/OAuthController.java
+++ b/src/main/java/com/backend/auth/presentation/OAuthController.java
@@ -1,6 +1,7 @@
 package com.backend.auth.presentation;
 
 import com.backend.auth.application.OAuthService;
+import com.backend.auth.presentation.dto.LoginRequestDto;
 import com.backend.global.common.response.CustomResponse;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
@@ -27,8 +28,8 @@ public class OAuthController {
     @PostMapping("/{provider}")
     public ResponseEntity<CustomResponse> login (
             @Parameter(description = "kakao, apple 중 현재 로그인하는 소셜 타입", in = ParameterIn.PATH) @PathVariable String provider,
-            @Parameter(description = "사용자 ID") @RequestParam String userId) {
-        return CustomResponse.success(LOGIN_SUCCESS, oauthService.login(provider, userId));
+            @RequestBody LoginRequestDto loginRequestDto) {
+        return CustomResponse.success(LOGIN_SUCCESS, oauthService.login(provider, loginRequestDto.userId(), loginRequestDto.fcmToken()));
     }
 
     @Operation(summary = "토큰 재발급",

--- a/src/main/java/com/backend/auth/presentation/dto/LoginRequestDto.java
+++ b/src/main/java/com/backend/auth/presentation/dto/LoginRequestDto.java
@@ -1,0 +1,12 @@
+package com.backend.auth.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record LoginRequestDto (
+
+        @NotNull(message = "userId는 빈 값일 수 없습니다.")
+        String userId,
+
+        @NotNull(message = "fcm token은 빈 값일 수 없습니다.")
+        String fcmToken
+) { }

--- a/src/test/java/com/backend/auth/application/OAuthServiceTest.java
+++ b/src/test/java/com/backend/auth/application/OAuthServiceTest.java
@@ -22,10 +22,11 @@ public class OAuthServiceTest {
     @Autowired
     private OAuthService oAuthService;
 
-    private static String uid = "user1234";
+    private static String UID = "user1234";
 
     private static String BEARER_TOKEN_PREFIX = "Bearer ";
 
+    private static String FCM_TOKEN = "fcm_token";
 
     @DisplayName("Access Token을 이용해 OAuth 인증 후 JWT를 발급한다.")
     @Test
@@ -34,7 +35,7 @@ public class OAuthServiceTest {
         String provider = "kakao";
 
         //  when
-        TokenResponse response = oAuthService.login(provider, uid);
+        TokenResponse response = oAuthService.login(provider, UID, FCM_TOKEN);
 
         // then
         assertThat(response.accessToken()).isNotNull();
@@ -48,14 +49,14 @@ public class OAuthServiceTest {
 
         // when & then
         assertThrows(BusinessException.class,
-                () -> oAuthService.login(provider, uid));
+                () -> oAuthService.login(provider, UID , FCM_TOKEN));
     }
 
     @DisplayName("access token이 만료되어 refresh token을 통해 재발급한다.")
     @Test
     public void reissueRefreshToken() throws Exception {
         // given
-        TokenResponse tokenResponse = oAuthService.login("kakao", uid);
+        TokenResponse tokenResponse = oAuthService.login("kakao", UID, FCM_TOKEN);
 
         // when
         TokenResponse renewTokenResponse = oAuthService.reissue(BEARER_TOKEN_PREFIX + tokenResponse.refreshToken());
@@ -78,7 +79,7 @@ public class OAuthServiceTest {
     @Test
     public void logoutSuccess(){
         // given
-        TokenResponse tokenResponse = oAuthService.login("kakao", uid);
+        TokenResponse tokenResponse = oAuthService.login("kakao", UID, FCM_TOKEN);
         // when & then
         assertThatNoException().isThrownBy(() -> oAuthService.withdraw( BEARER_TOKEN_PREFIX + tokenResponse.accessToken()));
     }

--- a/src/test/java/com/backend/auth/jwt/TokenProviderTest.java
+++ b/src/test/java/com/backend/auth/jwt/TokenProviderTest.java
@@ -1,7 +1,6 @@
 package com.backend.auth.jwt;
 
 import com.backend.auth.application.OAuthService;
-import com.backend.member.application.MemberService;
 import com.backend.member.domain.Member;
 import com.backend.member.domain.MemberRepository;
 import com.backend.member.domain.Provider;
@@ -20,8 +19,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 @SpringBootTest
 @ActiveProfiles("test")
 class TokenProviderTest {
-
-    private final static String TEST_SECRET_KEY = "test_secret_key";
 
     @Autowired
     TokenProvider tokenProvider;


### PR DESCRIPTION
### 1️⃣ 작업 내용 (Contents)

resolved : #31

* 로그인 컨트롤러 @requestbody로 수정, fcm token 추가
* FCM token을 Redis에 저장하도록 도메인 생성 및 Repository, Service 추가

### 3️⃣ 희망 리뷰 완료 일 (Expected due date)

클라이언트 측 요청으로 바로 머지할게요 !! 수정사항 있으면 추가로 PR 날리겠습니다~
