### PR TITLE
[Refactor/#47] 사용자 인증 필터에서 발생하는 예외 핸들러 필터 구현

### DIFF
--- a/src/main/java/com/backend/auth/application/BlackListService.java
+++ b/src/main/java/com/backend/auth/application/BlackListService.java
@@ -2,6 +2,8 @@ package com.backend.auth.application;
 
 import com.backend.auth.domain.BlackList;
 import com.backend.auth.domain.BlackListRepository;
+import com.backend.auth.jwt.exception.BlackListJwtException;
+import com.backend.auth.jwt.exception.InvalidJwtException;
 import com.backend.global.common.code.ErrorCode;
 import com.backend.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
@@ -18,9 +20,9 @@ public class BlackListService {
         blackListRepository.save(new BlackList(accessToken, expiration));
     }
 
-    public boolean isBlackList (String accessToken){
-        Optional<BlackList>  blackList = blackListRepository.findById(accessToken);
-        return blackList.isPresent();
+    public void checkBlackList(String accessToken){
+        BlackList blackList = blackListRepository.findById(accessToken)
+                .orElseThrow(() -> new BlackListJwtException(ErrorCode.BLACK_LIST_TOKEN));
     }
 
 }

--- a/src/main/java/com/backend/auth/jwt/exception/BlackListJwtException.java
+++ b/src/main/java/com/backend/auth/jwt/exception/BlackListJwtException.java
@@ -1,0 +1,11 @@
+package com.backend.auth.jwt.exception;
+
+import com.backend.global.common.code.ErrorCode;
+import com.backend.global.exception.BusinessException;
+
+public class BlackListJwtException extends BusinessException {
+
+    public BlackListJwtException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/backend/auth/jwt/exception/InvalidJwtException.java
+++ b/src/main/java/com/backend/auth/jwt/exception/InvalidJwtException.java
@@ -1,0 +1,13 @@
+package com.backend.auth.jwt.exception;
+
+import com.backend.global.common.code.ErrorCode;
+import com.backend.global.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class InvalidJwtException extends BusinessException {
+
+    public InvalidJwtException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/backend/auth/jwt/exception/JwtExpiredException.java
+++ b/src/main/java/com/backend/auth/jwt/exception/JwtExpiredException.java
@@ -1,0 +1,13 @@
+package com.backend.auth.jwt.exception;
+
+import com.backend.global.common.code.ErrorCode;
+import com.backend.global.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class JwtExpiredException extends BusinessException {
+
+    public JwtExpiredException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/backend/auth/jwt/exception/NullJwtException.java
+++ b/src/main/java/com/backend/auth/jwt/exception/NullJwtException.java
@@ -1,0 +1,11 @@
+package com.backend.auth.jwt.exception;
+
+import com.backend.global.common.code.ErrorCode;
+import com.backend.global.exception.BusinessException;
+
+public class NullJwtException extends BusinessException {
+
+    public NullJwtException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/backend/auth/jwt/filter/AuthenticationFilter.java
+++ b/src/main/java/com/backend/auth/jwt/filter/AuthenticationFilter.java
@@ -1,8 +1,7 @@
-package com.backend.auth.jwt;
+package com.backend.auth.jwt.filter;
 
 import com.backend.auth.application.BlackListService;
-import com.backend.global.common.code.ErrorCode;
-import com.backend.global.exception.BusinessException;
+import com.backend.auth.jwt.TokenProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,7 +17,7 @@ import java.io.IOException;
 
 @Slf4j
 @RequiredArgsConstructor
-public class JwtFilter extends OncePerRequestFilter {
+public class AuthenticationFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
 

--- a/src/main/java/com/backend/auth/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/backend/auth/jwt/filter/JwtExceptionFilter.java
@@ -1,0 +1,30 @@
+package com.backend.auth.jwt.filter;
+
+import com.backend.global.common.code.ErrorCode;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtException e){
+            setErrorResponse(request, response, e);
+        }
+    }
+
+    public void setErrorResponse(HttpServletRequest request, HttpServletResponse response, Throwable e) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, e.getMessage());
+    }
+}

--- a/src/main/java/com/backend/auth/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/backend/auth/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,4 +1,4 @@
-package com.backend.auth.jwt;
+package com.backend.auth.jwt.handler;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/backend/auth/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/backend/auth/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,4 +1,4 @@
-package com.backend.auth.jwt;
+package com.backend.auth.jwt.handler;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/backend/global/common/code/ErrorCode.java
+++ b/src/main/java/com/backend/global/common/code/ErrorCode.java
@@ -78,6 +78,8 @@ public enum ErrorCode {
 
     NO_TOKEN_PROVIDED(UNAUTHORIZED.value(), "AUTH-004", "토큰이 입력되지 않았습니다."),
 
+    BLACK_LIST_TOKEN(UNAUTHORIZED.value(), "AUTH-005", "로그아웃하거나 회원탈퇴한 사용자입니다."),
+
     /* Retrospect */
     RETROSPECT_IS_NOT_WRITTEN(NOT_FOUND.value(), "RETROSPECT-001", "회고가 작성되지 않은 상위 목표입니다."),
 

--- a/src/main/java/com/backend/global/common/code/ErrorCode.java
+++ b/src/main/java/com/backend/global/common/code/ErrorCode.java
@@ -72,9 +72,11 @@ public enum ErrorCode {
     /* Auth */
     TOKEN_EXPIRED(UNAUTHORIZED.value(), "AUTH-001", "토큰의 유효기간이 만료되었습니다."),
 
-    INVALID_TOKEN(BAD_REQUEST.value(), "AUTH-002", "토큰이 입력되지 않았거나 잘못된 형식의 토큰입니다."),
+    INVALID_TOKEN(BAD_REQUEST.value(), "AUTH-002", "잘못된 형식의 토큰 입력입니다."),
 
     MEMBER_NOT_FOUND(NOT_FOUND.value(), "AUTH-003", "회원이 존재하지 않습니다."),
+
+    NO_TOKEN_PROVIDED(UNAUTHORIZED.value(), "AUTH-004", "토큰이 입력되지 않았습니다."),
 
     /* Retrospect */
     RETROSPECT_IS_NOT_WRITTEN(NOT_FOUND.value(), "RETROSPECT-001", "회고가 작성되지 않은 상위 목표입니다."),

--- a/src/main/java/com/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/global/config/SecurityConfig.java
@@ -1,9 +1,9 @@
 package com.backend.auth.config;
 
 import com.backend.auth.application.BlackListService;
-import com.backend.auth.jwt.JwtAccessDeniedHandler;
-import com.backend.auth.jwt.JwtAuthenticationEntryPoint;
-import com.backend.auth.jwt.JwtFilter;
+import com.backend.auth.jwt.handler.JwtAccessDeniedHandler;
+import com.backend.auth.jwt.handler.JwtAuthenticationEntryPoint;
+import com.backend.auth.jwt.filter.AuthenticationFilter;
 import com.backend.auth.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -57,7 +57,7 @@ public class SecurityConfig {
                 .and()
 
                 .formLogin().disable()
-                .addFilterBefore(new JwtFilter(tokenProvider, blackListService), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new AuthenticationFilter(tokenProvider, blackListService), UsernamePasswordAuthenticationFilter.class);
         return httpSecurity.build();
     }
 }

--- a/src/main/java/com/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.backend.auth.config;
 
 import com.backend.auth.application.BlackListService;
+import com.backend.auth.jwt.filter.JwtExceptionFilter;
 import com.backend.auth.jwt.handler.JwtAccessDeniedHandler;
 import com.backend.auth.jwt.handler.JwtAuthenticationEntryPoint;
 import com.backend.auth.jwt.filter.AuthenticationFilter;
@@ -57,7 +58,8 @@ public class SecurityConfig {
                 .and()
 
                 .formLogin().disable()
-                .addFilterBefore(new AuthenticationFilter(tokenProvider, blackListService), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new AuthenticationFilter(tokenProvider, blackListService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), AuthenticationFilter.class); // AuthenticationFilter에서 발생한 예외가 JwtExceptionFilter에서 처리된다.
         return httpSecurity.build();
     }
 }


### PR DESCRIPTION
### 1️⃣ 작업 내용 (Contents)

resolved : #47 

### 2️⃣ 링크 (Links)

참고 : https://samtao.tistory.com/48

### 3️⃣ 희망 리뷰 완료 일 (Expected due date)

8/25

### 4️⃣ 기타 사항 (ETC)

추가로 궁금한 점이 있습니다! 

(1) 토큰 만료 시 = reissue 요청
(2) 토큰이 없는 경우 = 로그인 요청
(3) 토큰이 잘못된 경우 = 올바르지 않다는 메시지 반환

이런 식으로 구현할려고 했는데, ErrorCode가 달라지는 것 말고는 별 다른 처리할 것이 없다고 생각해서 setErrorResponse 메소드 하나로 통일하여 예외를 처리하였습니다. 이렇게 획일화하고 나니 그냥 JwtException 하나로만 서로 다른 ErrorCode를 넣어서 구현해도 같은 결과를 가져올 것 같아서, Exception 클래스의 분리의 필요성을 못느꼈습니다.

조언해주신 것처럼, 토큰 만료 시에는 reissue API를 요청할 수 있도록, 그리고 토큰이 없는 경우에는 재로그인 요청을 할 수 있도록 .. 등등 다양한 상황을 프론트에 전달해주기 위해 Exception 클래스를 저렇게 세분화하였는데, 결국에는 ErrorCode로 분리되는 점이라 굳이 Exception 클래스를 분리해야하나? 👀 하는 의문이 들어 질문 드립니다 !
