### PR TITLE
[Fix/#86] Dev 서버에서 Swagger API 호출시 403 Forbidden이 발생하는 문제를 해결한다

### DIFF
--- a/src/main/java/com/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/global/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.backend.auth.config;
+package com.backend.global.config;
 
 import com.backend.auth.application.BlackListService;
 import com.backend.auth.jwt.filter.JwtExceptionFilter;


### PR DESCRIPTION
### 1️⃣ 작업 내용 (Contents)

SecurityConfig 클래스 내의 package가 잘못 설정되어 있는걸 발견해서 수정 조치 했습니다. 이 부분이 직접적인 문제 원인이라고 확신이 되진 않지만 지속적으로 배포 하면서 문제점을 파악해보겠습니다.

resolved : #86 

### 2️⃣ 링크 (Links)

### 3️⃣ 희망 리뷰 완료 일 (Expected due date)

### 4️⃣ 기타 사항 (ETC)
