### PR TITLE
[Fix/#86] SwaggerConfig내 dev 서버의 URL 정보를 추가한다

### DIFF
--- a/src/main/java/com/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/global/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.backend.auth.config;
+package com.backend.global.config;
 
 import com.backend.auth.application.BlackListService;
 import com.backend.auth.jwt.filter.JwtExceptionFilter;

--- a/src/main/java/com/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/backend/global/config/SwaggerConfig.java
@@ -20,6 +20,7 @@ public class SwaggerConfig {
         testServer.setUrl("http://192.168.1.190:8080");
 
         return new OpenAPI()
+                .addServersItem(new Server().url("https://milestone-staging.site"))
                 .addServersItem(new Server().url("/"))
                 .info(
                         new Info()


### PR DESCRIPTION
### 1️⃣ 작업 내용 (Contents)

여전히 dev 서버에 대해서만 403 forbidden error가 발생하고 있어서 swaggerConfig에 직접 Server 객체를 통해 dev 서버의 url을 입력해줬습니다.

resolved : #86 

### 2️⃣ 링크 (Links)

### 3️⃣ 희망 리뷰 완료 일 (Expected due date)

### 4️⃣ 기타 사항 (ETC)

<img width="846" alt="스크린샷 2023-10-05 오후 4 24 44" src="https://github.com/dnd-side-project/dnd-9th-1-backend/assets/82302520/f3a567d9-3ed2-4355-999f-d3d185a0d052">

<br>

Postman을 사용해서 똑같은 API를 호출했을때는 정상적으로 로그인 처리가 되는걸 알 수 있습니다. 이를 통해 Nginx 웹서버의 nginx.conf나 어플리케이션의 SecurityConfig 설정 오류로 인한 문제는 아니라는걸 알 수 있습니다. 

Swagger 자체적인 설정 문제라고 생각되기에 SwaggerConfig의 설정을 조금 더 분석해보도록 하겠습니다. 직접 배포해봐야 문제 해결 여부를 알 수 있는 상황이 제일 곤란한것 같습니다🥲
