### PR TITLE
[Fix/#86] SecurityConfig내 URI 허용 여부를 판단하는 위치를 변경한다

### DIFF
--- a/src/main/java/com/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/global/config/SecurityConfig.java
@@ -27,11 +27,11 @@ public class SecurityConfig {
 
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer(){
-        return web -> web.ignoring()
-                .requestMatchers("/swagger-ui/**", "/api-docs/**", "/health", "/auth/**");
-    }
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer(){
+//        return web -> web.ignoring()
+//                .requestMatchers();
+//    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -48,7 +48,7 @@ public class SecurityConfig {
                     .frameOptions().disable()
                 .and()
                 .authorizeHttpRequests()
-
+                .requestMatchers("/swagger-ui/**", "/api-docs/**", "/health", "/auth/**").permitAll()
                 .anyRequest().authenticated()
 
                 .and()

--- a/src/main/java/com/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/global/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.backend.auth.config;
+package com.backend.global.config;
 
 import com.backend.auth.application.BlackListService;
 import com.backend.auth.jwt.filter.JwtExceptionFilter;

--- a/src/main/java/com/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/backend/global/config/SwaggerConfig.java
@@ -20,6 +20,7 @@ public class SwaggerConfig {
         testServer.setUrl("http://192.168.1.190:8080");
 
         return new OpenAPI()
+                .addServersItem(new Server().url("https://milestone-staging.site"))
                 .addServersItem(new Server().url("/"))
                 .info(
                         new Info()


### PR DESCRIPTION
### 1️⃣ 작업 내용 (Contents)

기존에 webIgnore를 통해서 permit하고 있던 URI들을 RequestMatcher를 통해서 permit하도록 변경해보겠습니다.

resolved : #86 

### 2️⃣ 링크 (Links)

### 3️⃣ 희망 리뷰 완료 일 (Expected due date)

### 4️⃣ 기타 사항 (ETC)
