### PR TITLE
[Feature/#90] 토큰 유효시간 수정 로직 개선

### DIFF
--- a/src/main/java/com/backend/auth/presentation/TokenController.java
+++ b/src/main/java/com/backend/auth/presentation/TokenController.java
@@ -5,15 +5,16 @@ import com.backend.auth.presentation.dto.request.ExpireTimeRequest;
 import com.backend.auth.presentation.dto.response.ExpireTimeResponse;
 import com.backend.global.common.response.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static com.backend.global.common.code.SuccessCode.SELECT_SUCCESS;
 import static com.backend.global.common.code.SuccessCode.UPDATE_SUCCESS;
 
+@Slf4j
 @Tag(name = "token", description = "토큰 관리 API입니다.")
 @RequiredArgsConstructor
 @RequestMapping("/token")
@@ -30,7 +31,7 @@ public class TokenController {
 
     @Operation(summary = "리프레시 토큰 유효 시간 수정", description = "리프레시 토큰의 유효 시간을 수정한다.")
     @PutMapping("/refresh/expire")
-    public ResponseEntity<CustomResponse<Void>> updateRefreshTokenExpireTime(@RequestBody ExpireTimeRequest expireTimeRequest){
+    public ResponseEntity<CustomResponse<Void>> updateRefreshTokenExpireTime(@RequestBody ExpireTimeRequest expireTimeRequest) {
         tokenProvider.updateRefreshTokenExpireTime(expireTimeRequest.toLong());
         return CustomResponse.success(UPDATE_SUCCESS);
     }

--- a/src/main/java/com/backend/auth/presentation/dto/response/ExpireTimeResponse.java
+++ b/src/main/java/com/backend/auth/presentation/dto/response/ExpireTimeResponse.java
@@ -1,7 +1,9 @@
 package com.backend.auth.presentation.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public record ExpireTimeResponse(
         @Schema(description = "만료 기한의 일수", example = "14")
         Long days,
@@ -27,7 +29,7 @@ public record ExpireTimeResponse(
         Long minutes = expireTime / 60;
         if(minutes != 0) expireTime %= minutes;
 
-        Long seconds = expireTime / 60;
+        Long seconds = expireTime;
         return new ExpireTimeResponse(days, hours, minutes, seconds);
     }
 }

--- a/src/main/java/com/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/backend/global/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                     .frameOptions().disable()
                 .and()
                 .authorizeHttpRequests()
-                .requestMatchers("/swagger-ui/**", "/api-docs/**", "/health", "/auth/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/api-docs/**", "/health", "/auth/**", "/token/**").permitAll()
                 .anyRequest().authenticated()
 
                 .and()


### PR DESCRIPTION
### 작업 내용 (Contents)

resolved : #90 

초 단위로 변형할 때 60을 한 번 더 곱하는 바람에 2초가 아닌 2분이 유효시간으로 설정되는 오류가 생겼다. 이를 해결하고, 토큰 관리 API는 편리를 위해 인증 없이 요청되도록 수정하였다.