### PR TITLE
[Feature/#92] Redis 내 리프레시 토큰의 TTL을 동적으로 설정

### DIFF
--- a/scripts/run_new_was.sh
+++ b/scripts/run_new_was.sh
@@ -13,7 +13,7 @@ echo "> Current port of running WAS is ${CURRENT_PORT}."
 if [ ${CURRENT_PORT} -eq 8081 ]; then
     TARGET_PORT=8082
 elif [ ${CURRENT_PORT} -eq 8082 ]; then
-    TARGET_PORT=8081
+    TARGET_PORT=8081ubu6
 else
     echo "> No WAS is connected to nginx"
 fi

--- a/src/main/generated/com/backend/detailgoal/domain/QDetailGoal.java
+++ b/src/main/generated/com/backend/detailgoal/domain/QDetailGoal.java
@@ -22,7 +22,7 @@ public class QDetailGoal extends EntityPathBase<DetailGoal> {
 
     public final com.backend.global.entity.QBaseEntity _super = new com.backend.global.entity.QBaseEntity(this);
 
-    public final ListPath<java.time.DayOfWeek, EnumPath<java.time.DayOfWeek>> alarmDays = this.<java.time.DayOfWeek, EnumPath<java.time.DayOfWeek>>createList("alarmDays", java.time.DayOfWeek.class, EnumPath.class, PathInits.DIRECT2);
+    public final SetPath<java.time.DayOfWeek, EnumPath<java.time.DayOfWeek>> alarmDays = this.<java.time.DayOfWeek, EnumPath<java.time.DayOfWeek>>createSet("alarmDays", java.time.DayOfWeek.class, EnumPath.class, PathInits.DIRECT2);
 
     public final BooleanPath alarmEnabled = createBoolean("alarmEnabled");
 

--- a/src/main/java/com/backend/auth/application/OAuthService.java
+++ b/src/main/java/com/backend/auth/application/OAuthService.java
@@ -30,11 +30,8 @@ public class OAuthService {
         String accessToken = tokenProvider.generateAccessToken(uid);
         String refreshToken = tokenProvider.generateRefreshToken(uid);
 
-        log.info("save refresh token to redis : uid = {}, refresh token = {}", uid, refreshToken);
-        refreshTokenService.saveRefreshToken(uid, refreshToken);
-
-        boolean checkRefreshTokenSaved = refreshTokenService.checkRefreshTokenSaved(uid, refreshToken);
-        log.info("check uid and refresh token saved : {}" , checkRefreshTokenSaved);
+        Long refreshTokenExpiration = tokenProvider.getRefreshTokenExpireTime();
+        refreshTokenService.saveRefreshToken(uid, refreshToken, refreshTokenExpiration);
 
         fcmTokenService.saveFcmToken(uid, fcmToken);
 
@@ -44,15 +41,15 @@ public class OAuthService {
     public ReissueResponse reissue(String bearerRefreshToken) throws Exception {
         String refreshToken = tokenProvider.getToken(bearerRefreshToken);
 
-        log.info("refresh token : " + refreshToken);
         String uid = refreshTokenService.findUidByRefreshToken(refreshToken);
 
-        log.info("uid : " + uid);
         String renewAccessToken = tokenProvider.generateAccessToken(uid);
         String renewRefreshToken = tokenProvider.generateRefreshToken(uid);
 
         refreshTokenService.deleteByUid(uid);
-        refreshTokenService.saveRefreshToken(uid, renewRefreshToken);
+
+        Long refreshTokenExpiration = tokenProvider.getRefreshTokenExpireTime();
+        refreshTokenService.saveRefreshToken(uid, renewRefreshToken, refreshTokenExpiration);
 
         return new ReissueResponse(renewAccessToken, renewRefreshToken);
     }

--- a/src/main/java/com/backend/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/backend/auth/application/RefreshTokenService.java
@@ -15,20 +15,14 @@ public class RefreshTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public void saveRefreshToken(String uid, String refreshToken){
-        refreshTokenRepository.save(new RefreshToken(uid, refreshToken));
+    public void saveRefreshToken(String uid, String refreshToken, Long expiration){
+        refreshTokenRepository.save(new RefreshToken(uid, refreshToken, expiration));
     }
 
     public String findUidByRefreshToken(String refreshToken){
         RefreshToken result = refreshTokenRepository.findByTokenValue(refreshToken)
                 .orElseThrow(() -> new BusinessException(ErrorCode.TOKEN_NOT_FOUND));
         return result.getUid();
-    }
-
-    public boolean checkRefreshTokenSaved(String uid, String refreshToken){
-        Optional<RefreshToken> result = refreshTokenRepository.findByUidAndTokenValue(uid, refreshToken);
-        if(result.isPresent()) return true;
-        return false;
     }
 
     public void deleteByUid(String uid) {

--- a/src/main/java/com/backend/auth/domain/RefreshToken.java
+++ b/src/main/java/com/backend/auth/domain/RefreshToken.java
@@ -4,15 +4,19 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @AllArgsConstructor
-@RedisHash(value = "refreshToken", timeToLive = 1000 * 60 * 60 * 24 * 14)
+@RedisHash(value = "refreshToken")
 public class RefreshToken {
     @Id
     private String uid;
 
     @Indexed
     private String tokenValue;
+
+    @TimeToLive
+    private Long expiration;
 }

--- a/src/test/java/com/backend/auth/application/RefreshTokenServiceTest.java
+++ b/src/test/java/com/backend/auth/application/RefreshTokenServiceTest.java
@@ -20,10 +20,10 @@ class RefreshTokenServiceTest {
     @DisplayName("사용자의 refresh token으로 UID를 반환한다.")
     void findUidByRefreshTokenTest(){
         // given
-        RefreshToken refreshToken = new RefreshToken("uid", "token value");
+        RefreshToken refreshToken = new RefreshToken("uid", "token value", 10000L);
 
         // when
-        refreshTokenService.saveRefreshToken(refreshToken.getUid(), refreshToken.getTokenValue());
+        refreshTokenService.saveRefreshToken(refreshToken.getUid(), refreshToken.getTokenValue(), refreshToken.getExpiration());
         String extractedUID = refreshTokenService.findUidByRefreshToken(refreshToken.getTokenValue());
 
         // then

--- a/src/test/java/com/backend/auth/domain/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/backend/auth/domain/RefreshTokenRepositoryTest.java
@@ -18,7 +18,7 @@ class RefreshTokenRepositoryTest {
     @Test
     void insertAndGetTest() {
         // given
-        RefreshToken refreshToken = new RefreshToken("uid", "refresh token");
+        RefreshToken refreshToken = new RefreshToken("uid", "refresh token", 10000L );
 
         // when
         refreshTokenRepository.save(refreshToken); // (refreshToken:"uid", refreshToken:tokenValue:"refresh token")


### PR DESCRIPTION
### 작업 내용 (Contents)

resolved : #92 

토큰의 유효기간이 동적으로 조정됨에 따라, 리프레시 토큰이 Redis에 저장되는 유효시간도 동적으로 변경해야한다. 
기존에 존재하는 Refresh Token의 TTL을 update하기보다는 , 새로 생성되는 리프레시 토큰 데이터에 대한 TTL을 현재 Expiration으로 설정할 수 있도록 한다.