### PR TITLE
[Feature/#95] 리프레시 토큰의 단위로 인한 오류 수정 및 재로그인 시 기존 토큰 삭제

### DIFF
--- a/src/main/java/com/backend/auth/application/OAuthService.java
+++ b/src/main/java/com/backend/auth/application/OAuthService.java
@@ -30,8 +30,12 @@ public class OAuthService {
         String accessToken = tokenProvider.generateAccessToken(uid);
         String refreshToken = tokenProvider.generateRefreshToken(uid);
 
+        if(refreshTokenService.existsRefreshToken(uid)){ // 재로그인 시 기존 리프레시 토큰 제거
+            refreshTokenService.deleteByUid(uid);
+        }
+
         Long refreshTokenExpiration = tokenProvider.getRefreshTokenExpireTime();
-        refreshTokenService.saveRefreshToken(uid, refreshToken, refreshTokenExpiration);
+        refreshTokenService.saveRefreshToken(uid, refreshToken, refreshTokenExpiration / 1000);
 
         fcmTokenService.saveFcmToken(uid, fcmToken);
 
@@ -49,7 +53,7 @@ public class OAuthService {
         refreshTokenService.deleteByUid(uid);
 
         Long refreshTokenExpiration = tokenProvider.getRefreshTokenExpireTime();
-        refreshTokenService.saveRefreshToken(uid, renewRefreshToken, refreshTokenExpiration);
+        refreshTokenService.saveRefreshToken(uid, renewRefreshToken, refreshTokenExpiration / 1000);
 
         return new ReissueResponse(renewAccessToken, renewRefreshToken);
     }
@@ -62,7 +66,7 @@ public class OAuthService {
         fcmTokenService.deleteByUid(uid);
 
         Long expiration = tokenProvider.getExpiration(accessToken);
-        blackListService.saveBlackList(accessToken, expiration);
+        blackListService.saveBlackList(accessToken, expiration / 1000);
     }
 
     public void withdraw(String bearerAccessToken)  {
@@ -74,7 +78,7 @@ public class OAuthService {
         fcmTokenService.deleteByUid(uid);
 
         Long expiration = tokenProvider.getExpiration(accessToken);
-        blackListService.saveBlackList(accessToken, expiration);
+        blackListService.saveBlackList(accessToken, expiration / 1000);
     }
 
 }

--- a/src/main/java/com/backend/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/backend/auth/application/RefreshTokenService.java
@@ -25,6 +25,11 @@ public class RefreshTokenService {
         return result.getUid();
     }
 
+    public boolean existsRefreshToken(String uid){
+        Optional<RefreshToken> result = refreshTokenRepository.findByUid(uid);
+        return !result.isEmpty();
+    }
+
     public void deleteByUid(String uid) {
         refreshTokenRepository.findById(uid).orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
         refreshTokenRepository.deleteById(uid);

--- a/src/main/java/com/backend/auth/domain/RefreshTokenRepository.java
+++ b/src/main/java/com/backend/auth/domain/RefreshTokenRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByTokenValue(String tokenValue);
 
-    Optional<RefreshToken> findByUidAndTokenValue(String uid, String tokenValue);
+    Optional<RefreshToken> findByUid(String uid);
 }


### PR DESCRIPTION
### 1️⃣ 작업 내용 (Contents)

resolved : #95 

*  Redis의 TTL이 초 단위인 것과 달리 JWT 토큰은 Ms 단위로 저장하기 때문에 토큰의 유효시간을 Redis의 TimeToLive와 동기화
* 재로그인 시 기존에 저장된 토큰 삭제

1. Redis 로그인 및 재로그인 테스트 -> 리프레시 토큰이 하나의 UID에 여러 개 쌓이는 문제 해결

**로그인 후**
![image](https://github.com/dnd-side-project/dnd-9th-1-backend/assets/67851124/cd7ce37e-b52b-443b-a99f-8ebb4a374064)

**재로그인 후**
![image](https://github.com/dnd-side-project/dnd-9th-1-backend/assets/67851124/d18e7479-ca90-45b2-860c-a40972700d20)
![image](https://github.com/dnd-side-project/dnd-9th-1-backend/assets/67851124/3a5d950b-08fe-4777-a27f-730cd47e7e80)

2. Redis 유효시간 만료에 따른 데이터 삭제 테스트 => 유효시간 만료 후 Redis에서 key가 UID인 데이터 (빨간 네모 박스)가 사라진다.

**로그인 후 토큰 만료 전**
![image](https://github.com/dnd-side-project/dnd-9th-1-backend/assets/67851124/f7ce8bc9-5fc0-4b3b-aa87-c18291ddcafd)
![image](https://github.com/dnd-side-project/dnd-9th-1-backend/assets/67851124/042dfc2f-7890-4842-ba6c-a466a0324b35)

**토큰 만료 후**
![image](https://github.com/dnd-side-project/dnd-9th-1-backend/assets/67851124/ad5aff91-9940-4256-851a-db497ed04cc3)

### 2️⃣ 링크 (Links)

https://freeblogger.tistory.com/10 

### 3️⃣ 희망 리뷰 완료 일 (Expected due date)

10.07

### 4️⃣ 기타 사항 (ETC)

유효기간이 정상적으로 반영되고, TTL이 경과함에 따라 Redis에서 자동 삭제되는 것을 확인하였으나, 클라이언트 테스트에는 다를 수 있어 피드백 후 수정할 예정입니다
