### PR TITLE
[Feature/#99] 하위 목표 수정 시 하위 목표 ID를 응답으로 반환한다

### DIFF
--- a/src/main/java/com/backend/detailgoal/application/DetailGoalService.java
+++ b/src/main/java/com/backend/detailgoal/application/DetailGoalService.java
@@ -87,14 +87,11 @@ public class DetailGoalService {
     }
 
     @Transactional
-    public Set<DayOfWeek> updateDetailGoal(Long detailGoalId, DetailGoalUpdateRequest detailGoalUpdateRequest)
+    public Long updateDetailGoal(Long detailGoalId, DetailGoalUpdateRequest detailGoalUpdateRequest)
     {
         DetailGoal detailGoal = detailGoalRepository.getByIdAndIsDeletedFalse(detailGoalId);
-        return detailGoal.update(detailGoalUpdateRequest.title(),
-                detailGoalUpdateRequest.alarmEnabled(),
-                detailGoalUpdateRequest.alarmTime(),
-                detailGoalUpdateRequest.alarmDays());
-
+        detailGoal.update(detailGoalUpdateRequest.title(), detailGoalUpdateRequest.alarmEnabled(), detailGoalUpdateRequest.alarmTime(), detailGoalUpdateRequest.alarmDays());
+        return detailGoal.getId();
     }
 
     @Transactional

--- a/src/main/java/com/backend/detailgoal/application/dto/response/DetailGoalResponse.java
+++ b/src/main/java/com/backend/detailgoal/application/dto/response/DetailGoalResponse.java
@@ -21,7 +21,7 @@ public record DetailGoalResponse(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "a hh:mm", timezone = "Asia/Seoul", locale = "ko")
         LocalTime alarmTime,
 
-        Set<DayOfWeek> alarmDays,
+        List<DayOfWeek> alarmDays,
 
         Boolean alarmEnabled
 )

--- a/src/main/java/com/backend/detailgoal/domain/DetailGoal.java
+++ b/src/main/java/com/backend/detailgoal/domain/DetailGoal.java
@@ -45,7 +45,7 @@ public class DetailGoal extends BaseEntity {
     @CollectionTable(name = "detail_goals_alarm_days", joinColumns = @JoinColumn(name = "detail_goal_id"))
     @Column(name = "alarm_days")
     @Enumerated(EnumType.STRING)
-    private Set<DayOfWeek> alarmDays;
+    private List<DayOfWeek> alarmDays;
 
     @Column(name = "alarm_time")
     private LocalTime alarmTime;
@@ -61,13 +61,13 @@ public class DetailGoal extends BaseEntity {
     }
 
 
-    public Set<DayOfWeek> update(String title, Boolean alarmEnabled, LocalTime alarmTime, List<String> alarmDays)
+    public void update(String title, Boolean alarmEnabled, LocalTime alarmTime, List<String> alarmDays)
     {
          validateTitleLength(title);
          this.title = title;
          this.alarmEnabled = alarmEnabled;
          this.alarmTime = alarmTime;
-         return updateAlarmDays(alarmDays);
+         this.alarmDays = alarmDays.stream().map(DayOfWeek::valueOf).collect(Collectors.toList());
     }
 
     private void validateTitleLength(final String title) {
@@ -84,7 +84,7 @@ public class DetailGoal extends BaseEntity {
         this.title = title;
         this.isCompleted = isCompleted;
         this.alarmEnabled = alarmEnabled;
-        this.alarmDays = new HashSet<>(alarmDays);
+        this.alarmDays = alarmDays;
         this.alarmTime = alarmTime;
     }
 
@@ -103,14 +103,5 @@ public class DetailGoal extends BaseEntity {
     public void inComplete()
     {
         this.isCompleted = Boolean.FALSE;
-    }
-
-    private Set<DayOfWeek> updateAlarmDays(List<String> alarmDays)
-    {
-        Set<DayOfWeek> copy = new HashSet<>(this.alarmDays);
-        Set<DayOfWeek> collect = alarmDays.stream().map(DayOfWeek::valueOf).collect(Collectors.toSet());
-        this.alarmDays = collect;
-        copy.removeAll(collect);
-        return copy;
     }
 }

--- a/src/main/java/com/backend/detailgoal/presentation/DetailGoalController.java
+++ b/src/main/java/com/backend/detailgoal/presentation/DetailGoalController.java
@@ -58,10 +58,10 @@ public class DetailGoalController {
     @Operation(summary = "하위 목표 수정", description = "하위 목표를 수정하는 API 입니다.")
     @ApiResponse(responseCode = "200", description = "code : 200, message : UPDATE_SUCCESS")
     @PatchMapping("/detail-goals/{id}")
-    public ResponseEntity<CustomResponse<Set<DayOfWeek>>> updateDetailGoal(@Parameter(description = "하위 목표 ID") @PathVariable Long id, @RequestBody @Valid DetailGoalUpdateRequest detailGoalUpdateRequest)
+    public ResponseEntity<CustomResponse<Long>> updateDetailGoal(@Parameter(description = "하위 목표 ID") @PathVariable Long id, @RequestBody @Valid DetailGoalUpdateRequest detailGoalUpdateRequest)
     {
-        Set<DayOfWeek> dayOfWeeks = detailGoalService.updateDetailGoal(id, detailGoalUpdateRequest);
-        return CustomResponse.success(UPDATE_SUCCESS, dayOfWeeks);
+        Long detailGoalId = detailGoalService.updateDetailGoal(id, detailGoalUpdateRequest);
+        return CustomResponse.success(UPDATE_SUCCESS, detailGoalId);
     }
 
     @Operation(summary = "하위 목표 삭제", description = "하위 목표를 삭제하는 API 입니다.")

--- a/src/main/java/com/backend/detailgoal/presentation/dto/request/DetailGoalSaveRequest.java
+++ b/src/main/java/com/backend/detailgoal/presentation/dto/request/DetailGoalSaveRequest.java
@@ -28,7 +28,7 @@ public record DetailGoalSaveRequest(
         @Schema(description = "알람 받을 시각", example = "오후 11:30")
         LocalTime alarmTime,
 
-        @Schema(description = "요일 정보", example = "[\"MONDAY\", \"TUSEDAY\", \"FRIDAY\"]")
+        @Schema(description = "요일 정보", example = "[\"MONDAY\", \"TUESDAY\", \"FRIDAY\"]")
         List<String> alarmDays
 ) {
 

--- a/src/main/java/com/backend/detailgoal/presentation/dto/request/DetailGoalUpdateRequest.java
+++ b/src/main/java/com/backend/detailgoal/presentation/dto/request/DetailGoalUpdateRequest.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -25,7 +26,7 @@ public record DetailGoalUpdateRequest(
         @Schema(description = "알람 받을 시각", example = "오후 11:30")
         LocalTime alarmTime,
 
-        @Schema(description = "요일 정보", example = "[\"MONDAY\", \"TUSEDAY\", \"FRIDAY\"]")
+        @Schema(description = "요일 정보", example = "[\"MONDAY\", \"TUESDAY\", \"FRIDAY\"]")
         List<String> alarmDays
 ) {
 }

--- a/src/test/java/com/backend/detailgoal/application/DetailGoalServiceTest.java
+++ b/src/test/java/com/backend/detailgoal/application/DetailGoalServiceTest.java
@@ -81,11 +81,11 @@ public class DetailGoalServiceTest {
 
         // when
         DetailGoalUpdateRequest detailGoalUpdateRequest = new DetailGoalUpdateRequest("수정된 제목", true, LocalTime.of(10, 0), List.of("TUESDAY", "FRIDAY"));
-        Set<DayOfWeek> dayOfWeeks = detailGoalService.updateDetailGoal(savedDetailGoal.getId(), detailGoalUpdateRequest);
+        detailGoalService.updateDetailGoal(savedDetailGoal.getId(), detailGoalUpdateRequest);
 
         // then
         DetailGoal updatedDetailGoal = detailGoalRepository.getByIdAndIsDeletedFalse(savedDetailGoal.getId());
-        assertThat(dayOfWeeks).hasSize(1);
+        assertThat(updatedDetailGoal.getAlarmDays()).containsExactlyInAnyOrder(DayOfWeek.TUESDAY, DayOfWeek.FRIDAY);
     }
 
     @DisplayName("하위 목표를 삭제하면 상위 목표의 하위 목표 카운트가 감소한다.")


### PR DESCRIPTION
### 1️⃣ 작업 내용 (Contents)

기존에는 클라이언트의 로컬 알림을 위해 하위 목표의 alarmDays 수정 시, 기존 alarmDays와 새로운 alarmDays의 차집합을 응답값으로 반환했습니다. 이후 차집합을 반환하지 않는걸로 요구사항이 변경되었고 하위 목표 수정 시 ID만 응답값으로 반환하도록 구현했습니다.

close : #99

작업한 내용을 정리해주세요.

### 2️⃣ 링크 (Links)

### 3️⃣ 희망 리뷰 완료 일 (Expected due date)

### 4️⃣ 기타 사항 (ETC)
응답으로 반환하는 하위 목표 ID의 경우, 하위 목표를 수정하기 위해 요청을 보낼때 이미 **하위 목표를 식별하기 위해 함께 보내줍니다**. 그렇다면 리소스를 새로 생성하는 작업이 아니고 클라이언트는 이미 하위 목표 ID를 보유하고 있기 때문에, 이 응답값이 필요한지에 대한 논의가 더 필요합니다.
